### PR TITLE
Add errorhandler middleware for backend express api

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,8 +12,10 @@
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
+        "express-async-errors": "^3.1.1",
         "mongoose": "^8.1.3",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
       },
       "devDependencies": {
         "eslint": "^8.56.0",
@@ -1320,6 +1322,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -3574,6 +3584,17 @@
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.0.3.tgz",
+      "integrity": "sha512-cETTrcMq3Ze58vhdR0zD37uJm/694I6mAxcf/ei5bl89cC++fBNxrC2z8lkFze/8hVMPwrbtrwXHR2LB50fpHw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,9 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
+    "express-async-errors": "^3.1.1",
     "mongoose": "^8.1.3",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zod-validation-error": "^3.0.3"
   }
 }

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,10 +1,14 @@
+import "express-async-errors";
 import express from "express";
 import minutesController from "./controllers/minutesController.js";
+import errorHandler from "./utils/errorHandler.js";
 
 const app = express();
 
 app.use(express.json());
 
 app.use("/api/minutes", minutesController);
+
+app.use(errorHandler);
 
 export default app;

--- a/server/src/controllers/minutesController.js
+++ b/server/src/controllers/minutesController.js
@@ -1,20 +1,27 @@
 import { Router as createRouter } from "express";
-
 import minutesService from "../services/minutesService.js";
 import minutesSchema from "../schemas/minutesSchema.js";
+import idParamsSchema from "../schemas/idParamsSchema.js";
 
 const minutesController = createRouter();
 
+const sendMinutesNotFound = (response) =>
+  response.status(404).json({ error: "Minutes not found with the given id" });
+
 minutesController.get("/:id", async (request, response) => {
-  const { id } = request.params;
+  const { id } = await idParamsSchema.parseAsync(request.params);
 
   const minutes = await minutesService.getMinutesById(id);
+
+  if (!minutes) {
+    sendMinutesNotFound(response);
+  }
 
   return response.json(minutes);
 });
 
 minutesController.post("/", async (request, response) => {
-  const minutesBody = minutesSchema.parse(request.body);
+  const minutesBody = await minutesSchema.parseAsync(request.body);
 
   const createdMinutes = await minutesService.createMinutes(minutesBody);
 
@@ -22,18 +29,25 @@ minutesController.post("/", async (request, response) => {
 });
 
 minutesController.put("/:id", async (request, response) => {
-  const { id } = request.params;
-  const minutesBody = minutesSchema.parse(request.body);
+  const { id } = await idParamsSchema.parseAsync(request.params);
+  const minutesBody = await minutesSchema.parseAsync(request.body);
 
   const updatedMinutes = await minutesService.updateMinutes(id, minutesBody);
+
+  if (!updatedMinutes) {
+    sendMinutesNotFound(response);
+  }
 
   return response.json(updatedMinutes);
 });
 
 minutesController.delete("/:id", async (request, response) => {
-  const { id } = request.params;
-
+  const { id } = await idParamsSchema.parseAsync(request.params);
   const deletedMinutes = await minutesService.deleteMinutesById(id);
+
+  if (!deletedMinutes) {
+    sendMinutesNotFound(response);
+  }
 
   return response.json(deletedMinutes);
 });

--- a/server/src/schemas/idParamsSchema.js
+++ b/server/src/schemas/idParamsSchema.js
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+const mongoIdSchema = z
+  .string()
+  .refine((value) => /^[0-9a-fA-F]{24}$/.test(value), {
+    message: "Invalid MongoDB id",
+  });
+
+const idParamsSchema = z.object({
+  id: mongoIdSchema,
+});
+
+export default idParamsSchema;

--- a/server/src/utils/errorHandler.js
+++ b/server/src/utils/errorHandler.js
@@ -1,0 +1,18 @@
+import { ZodError } from "zod";
+import { fromZodError } from "zod-validation-error";
+
+const errorHandler = (error, request, response, next) => {
+  if (error instanceof ZodError) {
+    const validationError = fromZodError(error);
+    response.status(400).json({ error: validationError.toString() });
+  }
+
+  if (error instanceof Error) {
+    response.status(500).json({ error: "Unexpected error occured" });
+    console.error("Unexpected Error", { error });
+  }
+
+  next(error);
+};
+
+export default errorHandler;


### PR DESCRIPTION
Added error handling to express. Request validation errors are handled and the rest are just unexpect errors at this point (in the client's point of view). All unexpected errors are logged to client.

404 errors are also sent when minutes are not found with the given id, but these won't go through the errorHandler.

Closes #16