### PR TITLE
61 use json web token as id in minutescontroller

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Run tests on Server
         working-directory: ./server
         run: npm test
+        env:
+            SECRET: testsecret
 
       - name: Install the Client dependencies
         working-directory: ./client

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^4.18.3",
         "express-async-errors": "^3.1.1",
         "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.1.3",
         "zod": "^3.22.4",
         "zod-validation-error": "^3.0.3"
@@ -3672,6 +3673,11 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4218,6 +4224,14 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -6768,6 +6782,46 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -6852,17 +6906,51 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -8317,7 +8405,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9326,8 +9413,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
     "express": "^4.18.3",
     "express-async-errors": "^3.1.1",
     "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.3",
     "zod": "^3.22.4",
     "zod-validation-error": "^3.0.3"

--- a/server/src/controllers/minutesController.helpers.js
+++ b/server/src/controllers/minutesController.helpers.js
@@ -1,0 +1,28 @@
+import jwt from "jsonwebtoken";
+
+import tokenSchema from "../schemas/tokenSchema.js";
+import environment from "../utils/environment.js";
+import { TokenError } from "../utils/errors.js";
+
+export const sendMinutesNotFound = (response) =>
+  response
+    .status(404)
+    .json({ error: "Minutes not found with the given token" });
+
+export const createJwt = (id, writeAccess) => {
+  const tokenContent = { id, writeAccess };
+  const token = jwt.sign(tokenContent, environment.secret);
+
+  return token;
+};
+
+export const parseJwt = async (token) => {
+  try {
+    const decodedToken = jwt.verify(token, environment.secret);
+    const parsedToken = await tokenSchema.parseAsync(decodedToken);
+
+    return parsedToken;
+  } catch (error) {
+    throw new TokenError(error.message);
+  }
+};

--- a/server/src/controllers/minutesController.js
+++ b/server/src/controllers/minutesController.js
@@ -43,7 +43,7 @@ minutesController.put("/:token", async (request, response) => {
   const { id, writeAccess } = await parseJwt(token);
 
   if (!writeAccess) {
-    return response.status(401);
+    return response.sendStatus(401);
   }
 
   const minutesBody = await minutesSchema.parseAsync(request.body);
@@ -64,7 +64,7 @@ minutesController.delete("/:token", async (request, response) => {
   const { id, writeAccess } = await parseJwt(token);
 
   if (!writeAccess) {
-    return response.status(401);
+    return response.sendStatus(401);
   }
 
   const deletedMinutes = await minutesService.deleteMinutesById(id);

--- a/server/src/controllers/minutesController.js
+++ b/server/src/controllers/minutesController.js
@@ -1,15 +1,18 @@
 import { Router as createRouter } from "express";
+
 import minutesService from "../services/minutesService.js";
 import minutesSchema from "../schemas/minutesSchema.js";
-import idParamsSchema from "../schemas/idParamsSchema.js";
+import {
+  createJwt,
+  parseJwt,
+  sendMinutesNotFound,
+} from "./minutesController.helpers.js";
 
 const minutesController = createRouter();
 
-const sendMinutesNotFound = (response) =>
-  response.status(404).json({ error: "Minutes not found with the given id" });
-
-minutesController.get("/:id", async (request, response) => {
-  const { id } = await idParamsSchema.parseAsync(request.params);
+minutesController.get("/:token", async (request, response) => {
+  const { token } = request.params;
+  const { id, writeAccess } = await parseJwt(token);
 
   const minutes = await minutesService.getMinutesById(id);
 
@@ -17,7 +20,9 @@ minutesController.get("/:id", async (request, response) => {
     return sendMinutesNotFound(response);
   }
 
-  return response.json(minutes);
+  const responseBody = { data: minutes, writeAccess };
+
+  return response.json(responseBody);
 });
 
 minutesController.post("/", async (request, response) => {
@@ -25,11 +30,22 @@ minutesController.post("/", async (request, response) => {
 
   const createdMinutes = await minutesService.createMinutes(minutesBody);
 
-  return response.json(createdMinutes);
+  const readToken = createJwt(createdMinutes.id, false);
+  const writeToken = createJwt(createdMinutes.id, true);
+
+  const responseBody = { data: createdMinutes, readToken, writeToken };
+
+  return response.status(201).json(responseBody);
 });
 
-minutesController.put("/:id", async (request, response) => {
-  const { id } = await idParamsSchema.parseAsync(request.params);
+minutesController.put("/:token", async (request, response) => {
+  const { token } = request.params;
+  const { id, writeAccess } = await parseJwt(token);
+
+  if (!writeAccess) {
+    return response.status(401);
+  }
+
   const minutesBody = await minutesSchema.parseAsync(request.body);
 
   const updatedMinutes = await minutesService.updateMinutes(id, minutesBody);
@@ -38,18 +54,28 @@ minutesController.put("/:id", async (request, response) => {
     return sendMinutesNotFound(response);
   }
 
-  return response.json(updatedMinutes);
+  const responseBody = { data: updatedMinutes };
+
+  return response.json(responseBody);
 });
 
-minutesController.delete("/:id", async (request, response) => {
-  const { id } = await idParamsSchema.parseAsync(request.params);
+minutesController.delete("/:token", async (request, response) => {
+  const { token } = request.params;
+  const { id, writeAccess } = await parseJwt(token);
+
+  if (!writeAccess) {
+    return response.status(401);
+  }
+
   const deletedMinutes = await minutesService.deleteMinutesById(id);
 
   if (!deletedMinutes) {
     return sendMinutesNotFound(response);
   }
 
-  return response.json(deletedMinutes);
+  const responseBody = { data: deletedMinutes };
+
+  return response.json(responseBody);
 });
 
 export default minutesController;

--- a/server/src/schemas/tokenSchema.js
+++ b/server/src/schemas/tokenSchema.js
@@ -6,8 +6,9 @@ const mongoIdSchema = z
     message: "Invalid MongoDB id",
   });
 
-const idParamsSchema = z.object({
+const tokenSchema = z.object({
   id: mongoIdSchema,
+  writeAccess: z.boolean(),
 });
 
-export default idParamsSchema;
+export default tokenSchema;

--- a/server/src/tests/api.test.js
+++ b/server/src/tests/api.test.js
@@ -143,6 +143,13 @@ describe("minutesApi", () => {
         "Minutes not found with the given token",
       );
     });
+
+    it("should respond with 401 when writeAccess is false in the token", async () => {
+      const token = getTokenWithoutWriteAccess(minutesInDb.id);
+      const response = await api.put(`${baseUrl}/${token}`);
+
+      expect(response.status).toBe(401);
+    });
   });
 
   describe("delete", () => {
@@ -169,6 +176,13 @@ describe("minutesApi", () => {
       expect(response.body.error).toEqual(
         "Minutes not found with the given token",
       );
+    });
+
+    it("should respond with 401 when writeAccess is false in the token", async () => {
+      const token = getTokenWithoutWriteAccess(minutesInDb.id);
+      const response = await api.delete(`${baseUrl}/${token}`);
+
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/server/src/tests/api.test.js
+++ b/server/src/tests/api.test.js
@@ -4,6 +4,7 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 import app from "../app.js";
 import dummyMinutes from "../../data/dummyMinutes.json";
 import Minutes from "../entities/minutes.js";
+import { createJwt } from "../controllers/minutesController.helpers.js";
 
 describe("minutesApi", () => {
   const baseUrl = "/api/minutes";
@@ -32,40 +33,61 @@ describe("minutesApi", () => {
     await Minutes.deleteMany({});
   });
 
+  const getTokenWithoutWriteAccess = (id) => createJwt(id, false);
+  const getTokenWithWriteAccess = (id) => createJwt(id, true);
+
   describe("get", () => {
-    it("should responds with 200 and minutes body when id is valid and minutes are found", async () => {
-      const response = await api.get(`${baseUrl}/${minutesInDb.id}`);
+    it("should responds with 200, minutes and writeAccess when token (without writeAccess) is valid and minutes are found", async () => {
+      const token = getTokenWithoutWriteAccess(minutesInDb.id);
+      const response = await api.get(`${baseUrl}/${token}`);
+
       expect(response.status).toBe(200);
-      expect(response.body).toEqual(expect.objectContaining(dummyMinutes));
+      expect(response.body.data).toEqual(expect.objectContaining(dummyMinutes));
+      expect(response.body.writeAccess).toBe(false);
+    });
+
+    it("should responds with 200, minutes and writeAccess when token (with writeAccess) is valid and minutes are found", async () => {
+      const token = getTokenWithWriteAccess(minutesInDb.id);
+      const response = await api.get(`${baseUrl}/${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(expect.objectContaining(dummyMinutes));
+      expect(response.body.writeAccess).toBe(true);
     });
 
     it("should respond with 404 and error message when id doesn't exist in the database", async () => {
-      const response = await api.get(`${baseUrl}/${validNonExistentId}`);
+      const token = getTokenWithWriteAccess(validNonExistentId);
+      const response = await api.get(`${baseUrl}/${token}`);
+
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(
-        "Minutes not found with the given id",
+        "Minutes not found with the given token",
       );
     });
 
     it("should respond with 400 and validation error message when id isn't a valid mongodb id (hexadecimal value with 24 characters)", async () => {
       const response = await api.get(`${baseUrl}/${invalidId}`);
+
       expect(response.status).toBe(400);
-      expect(response.body.error).toEqual(
-        'Validation error: Invalid MongoDB id at "id"',
-      );
+      expect(response.body.error).toEqual("Token invalid or missing");
     });
   });
 
   describe("post", () => {
     it("should respond with 200 and the created minutes when given valid minutes object", async () => {
       const response = await api.post(`${baseUrl}/`).send(dummyMinutes);
-      expect(response.status).toBe(200);
+
+      expect(response.status).toBe(201);
+      expect(response.body.data).toEqual(expect.objectContaining(dummyMinutes));
+      expect(response.body.readToken).toBeDefined();
+      expect(response.body.writeToken).toBeDefined();
     });
 
     it("should respond with 400 and validation error message when given invalid minutes object in request body", async () => {
       const response = await api
         .post(`${baseUrl}/`)
         .send({ ...dummyMinutes, name: undefined });
+
       expect(response.status).toBe(400);
       expect(response.body.error).toEqual(
         'Validation error: Required at "name"',
@@ -75,30 +97,33 @@ describe("minutesApi", () => {
 
   describe("put", () => {
     it("should respond with 200 and the updated minutes when given valid id and minutes body", async () => {
+      const token = getTokenWithWriteAccess(minutesInDb.id);
       const updatedMinutes = { ...dummyMinutes, name: "updated minutes" };
 
       const response = await api
-        .put(`${baseUrl}/${minutesInDb.id}`)
+        .put(`${baseUrl}/${token}`)
         .send(updatedMinutes);
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual(expect.objectContaining(updatedMinutes));
-    });
-
-    it("should respond with 400 and error message when given invalid id (hexadecimal value with 24 characters)", async () => {
-      const response = await api
-        .put(`${baseUrl}/${invalidId}`)
-        .send({ ...dummyMinutes, name: "updated minutes" });
-
-      expect(response.status).toBe(400);
-      expect(response.body.error).toEqual(
-        'Validation error: Invalid MongoDB id at "id"',
+      expect(response.body.data).toEqual(
+        expect.objectContaining(updatedMinutes),
       );
     });
 
-    it("should respond with 400 and error message when given invalid body", async () => {
+    it("should respond with 400 and error message when given invalid id (hexadecimal value with 24 characters)", async () => {
+      const token = getTokenWithWriteAccess(invalidId);
       const response = await api
-        .put(`${baseUrl}/${validNonExistentId}`)
+        .put(`${baseUrl}/${token}`)
+        .send({ ...dummyMinutes, name: "updated minutes" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toEqual("Token invalid or missing");
+    });
+
+    it("should respond with 400 and error message when given invalid body", async () => {
+      const token = getTokenWithWriteAccess(minutesInDb.id);
+      const response = await api
+        .put(`${baseUrl}/${token}`)
         .send({ ...dummyMinutes, name: undefined });
 
       expect(response.status).toBe(400);
@@ -108,40 +133,41 @@ describe("minutesApi", () => {
     });
 
     it("should respond with 404 and error message when id doesn't exist in the database", async () => {
+      const token = getTokenWithWriteAccess(validNonExistentId);
       const response = await api
-        .put(`${baseUrl}/${validNonExistentId}`)
+        .put(`${baseUrl}/${token}`)
         .send({ ...dummyMinutes, name: "updated minutes" });
 
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(
-        "Minutes not found with the given id",
+        "Minutes not found with the given token",
       );
     });
   });
 
   describe("delete", () => {
     it("should respond with 200 and the deleted minutes when given valid id", async () => {
-      const response = await api.delete(`${baseUrl}/${minutesInDb.id}`);
+      const token = getTokenWithWriteAccess(minutesInDb.id);
+      const response = await api.delete(`${baseUrl}/${token}`);
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual(expect.objectContaining(dummyMinutes));
+      expect(response.body.data).toEqual(expect.objectContaining(dummyMinutes));
     });
 
     it("should respond with 400 and validation error message when id isn't a valid mongodb id (hexadecimal value with 24 characters)", async () => {
       const response = await api.delete(`${baseUrl}/${invalidId}`);
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toEqual(
-        'Validation error: Invalid MongoDB id at "id"',
-      );
+      expect(response.body.error).toEqual("Token invalid or missing");
     });
 
     it("should respond with 404 and error message when id doesn't exist in the database", async () => {
-      const response = await api.delete(`${baseUrl}/${validNonExistentId}`);
+      const token = getTokenWithWriteAccess(validNonExistentId);
+      const response = await api.delete(`${baseUrl}/${token}`);
 
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(
-        "Minutes not found with the given id",
+        "Minutes not found with the given token",
       );
     });
   });

--- a/server/src/utils/environment.js
+++ b/server/src/utils/environment.js
@@ -8,6 +8,8 @@ const mongodbDevConnectionstring = process.env.MONGODB_DEV_CONNECTION_STRING;
 
 const port = Number(process.env.PORT) || 8080; // If doesn't exist OR not a number, defaults as 8080
 
+const secret = process.env.SECRET;
+
 // Errorhandling
 
 if (!nodeEnv) {
@@ -29,6 +31,11 @@ if (nodeEnv === "development" && !mongodbDevConnectionstring) {
   process.exit();
 }
 
+if (!secret) {
+  console.error("SECRET is not set. Aborting.");
+  process.exit();
+}
+
 // Decide db connectionstring based on node env
 
 const dbConnectionstring =
@@ -40,6 +47,7 @@ const environment = {
   nodeEnv,
   dbConnectionstring,
   port,
+  secret,
 };
 
 export default environment;

--- a/server/src/utils/errorHandler.js
+++ b/server/src/utils/errorHandler.js
@@ -1,10 +1,15 @@
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
+import { TokenError } from "./errors.js";
 
 const errorHandler = (error, request, response, next) => {
   if (error instanceof ZodError) {
     const validationError = fromZodError(error);
     return response.status(400).json({ error: validationError.toString() });
+  }
+
+  if (error instanceof TokenError) {
+    return response.status(400).json({ error: "Token invalid or missing" });
   }
 
   if (error instanceof Error) {

--- a/server/src/utils/errors.js
+++ b/server/src/utils/errors.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */ // This can be removed if other custom errors are created
+export class TokenError extends Error {}


### PR DESCRIPTION
JSON Web Tokens are now used instead of MongoDB ids to GET, PUT and DELETE minutes. This is to restrict access without having users sign in. This is what I like to call authorization-without-authentication and I would like academic recognition from inventing it (even though it has been done before and most likely better).

Authentication asks the question "Who are you?" and this server doesn't give a **** who you are. If you have a write access token, here's the data!

closes #61 