### PR TITLE
Added Vite proxy config

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -17,4 +17,12 @@ export default defineConfig({
     include: /(src)\/.*\.jsx?$/,
     exclude: [],
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Vite forwards any requests on the development server addressed to /api path to localhost 8080 where the server runs by default. It also disguises the origin so CORS settings don't have to be configured on the server.

Closes #59 