### PR TITLE
Fixed node_module being overwritten in docker compose dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,7 @@ services:
       dockerfile: Dockerfile.dev
     volumes:
       - ./client:/usr/src/app/client
+      - /usr/src/app/client/node_modules/
     ports:
       - 5173:5173
     depends_on:
@@ -36,6 +37,7 @@ services:
       dockerfile: Dockerfile.dev
     volumes:
       - ./server:/usr/src/app/server
+      - /usr/src/app/server/node_modules/
     environment:
       PORT: 8080
       MONGODB_DEV_CONNECTION_STRING: mongodb://localhost:27017/tablebook_dev


### PR DESCRIPTION
Added new volumes for node_modules so the node_modules folder won't sync with host machine.

Closes #130 