### PR TITLE
make the colorpickers save the colors to the minutescontext

### DIFF
--- a/client/src/components/SideBar.jsx
+++ b/client/src/components/SideBar.jsx
@@ -15,12 +15,8 @@ import flagEn from "../i18n/locales/flags/en.svg";
 const SideBar = ({ handleModalOpen }) => {
   const [isLanguagePickerOpen, setIsLanguagePickerOpen] = useState(false);
   const [language, setLanguage] = useState("en");
-  const [textColor, setTextColor] = useState(
-    sessionStorage.getItem("textColor") || "#000000",
-  );
-  const [backgroundColor, setBackgroundColor] = useState(
-    sessionStorage.getItem("backgroundColor") || "#ffffff",
-  );
+  const [textColor, setTextColor] = useState("#000000");
+  const [backgroundColor, setBackgroundColor] = useState("#ffffff");
 
   const { t, i18n } = useTranslation();
 
@@ -29,18 +25,14 @@ const SideBar = ({ handleModalOpen }) => {
   const restoreDefaults = () => {
     setTextColor("#000000");
     setBackgroundColor("#ffffff");
-    sessionStorage.setItem("textColor", "#000000");
-    sessionStorage.setItem("backgroundColor", "#ffffff");
   };
 
   const handleTextColorChange = (color) => {
     setTextColor(color);
-    sessionStorage.setItem("textColor", color);
   };
 
   const handleBackgroundColorChange = (color) => {
     setBackgroundColor(color);
-    sessionStorage.setItem("backgroundColor", color);
   };
 
   const handleLanguageChange = (language) => {

--- a/client/src/components/SideBar.test.jsx
+++ b/client/src/components/SideBar.test.jsx
@@ -1,10 +1,48 @@
 import { expect, test, describe, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import MinutesContext from "../contexts/MinutesContext.jsx";
 import SideBar from "./SideBar.jsx";
 
 describe("SideBar", () => {
+  const mockedContext = {
+    minutes: {
+      name: "",
+      colors: {
+        primary: "#000000",
+        secondary: "#FFFFFF",
+      },
+      segments: [
+        {
+          name: "Agenda",
+          content: "Some content",
+        },
+        {
+          name: "Decisions",
+          content: "Some content",
+        },
+      ],
+      startTime: null,
+      signatures: [],
+    },
+
+    metadata: {
+      writeAccess: null,
+      token: null,
+    },
+  };
+
+  const MockedProvider = ({ children }) => (
+    <MinutesContext.Provider value={[mockedContext]}>
+      {children}
+    </MinutesContext.Provider>
+  );
+
   beforeEach(() => {
-    render(<SideBar />);
+    render(
+      <MockedProvider>
+        <SideBar />
+      </MockedProvider>,
+    );
   });
 
   test("renders the primary color element", () => {

--- a/client/src/components/SideBar.test.jsx
+++ b/client/src/components/SideBar.test.jsx
@@ -8,26 +8,9 @@ describe("SideBar", () => {
     minutes: {
       name: "",
       colors: {
-        primary: "#000000",
-        secondary: "#FFFFFF",
+        primary: "#0000FF",
+        secondary: "#FF00FF",
       },
-      segments: [
-        {
-          name: "Agenda",
-          content: "Some content",
-        },
-        {
-          name: "Decisions",
-          content: "Some content",
-        },
-      ],
-      startTime: null,
-      signatures: [],
-    },
-
-    metadata: {
-      writeAccess: null,
-      token: null,
     },
   };
 
@@ -43,6 +26,30 @@ describe("SideBar", () => {
         <SideBar />
       </MockedProvider>,
     );
+  });
+
+  test("color picker colors are equal to editor colors", () => {
+    const colorPickerBoxes = screen.getAllByTestId("color-picker-box");
+    const backgroundColor = window
+      .getComputedStyle(colorPickerBoxes[0])
+      .getPropertyValue("background-color");
+    const rgbMatch = backgroundColor.match(/rgb\((\d+), (\d+), (\d+)\)/);
+    if (rgbMatch) {
+      const red = parseInt(rgbMatch[1], 10)
+        .toString(16)
+        .toUpperCase()
+        .padStart(2, "0");
+      const green = parseInt(rgbMatch[2], 10)
+        .toString(16)
+        .toUpperCase()
+        .padStart(2, "0");
+      const blue = parseInt(rgbMatch[3], 10)
+        .toString(16)
+        .toUpperCase()
+        .padStart(2, "0");
+      const actualHex = `#${red}${green}${blue}`;
+      expect(actualHex).toBe(mockedContext.minutes.colors.primary);
+    }
   });
 
   test("renders the primary color element", () => {


### PR DESCRIPTION
- removed session storage connections from sidebar
- connected colorpickers to minutes context
- created debouncer function to reduce rapid state updates(sliding the color picker) which would cause error
- adjusted tests to mock minutes context
- wrote new test to check if color picker colors match context colors
  - made rgb to hex converter, cause js represent colors in rgb format