### PR TITLE
142 add tokens to get requests

### DIFF
--- a/client/src/schemas/responseSchemas.js
+++ b/client/src/schemas/responseSchemas.js
@@ -4,6 +4,8 @@ import minutesSchema from "./minutesSchema";
 export const getMinutesResponseSchema = z.object({
   data: minutesSchema,
   writeAccess: z.boolean(),
+  readToken: z.string(),
+  writeToken: z.string().optional(),
 });
 
 export const postMinutesResponseSchema = z.object({

--- a/server/src/controllers/minutesController.js
+++ b/server/src/controllers/minutesController.js
@@ -20,7 +20,10 @@ minutesController.get("/:token", async (request, response) => {
     return sendMinutesNotFound(response);
   }
 
-  const responseBody = { data: minutes, writeAccess };
+  const readToken = createJwt(minutes.id, false);
+  const writeToken = (writeAccess) ? createJwt(minutes.id, true) : undefined;
+
+  const responseBody = { data: minutes, writeAccess, readToken, writeToken };
 
   return response.json(responseBody);
 });

--- a/server/src/controllers/minutesController.js
+++ b/server/src/controllers/minutesController.js
@@ -21,7 +21,7 @@ minutesController.get("/:token", async (request, response) => {
   }
 
   const readToken = createJwt(minutes.id, false);
-  const writeToken = (writeAccess) ? createJwt(minutes.id, true) : undefined;
+  const writeToken = writeAccess ? createJwt(minutes.id, true) : undefined;
 
   const responseBody = { data: minutes, writeAccess, readToken, writeToken };
 

--- a/server/src/tests/api.test.js
+++ b/server/src/tests/api.test.js
@@ -44,6 +44,8 @@ describe("minutesApi", () => {
       expect(response.status).toBe(200);
       expect(response.body.data).toEqual(expect.objectContaining(dummyMinutes));
       expect(response.body.writeAccess).toBe(false);
+      expect(response.body.readToken).toBeDefined();
+      expect(response.body.writeToken).not.toBeDefined();
     });
 
     it("should responds with 200, minutes and writeAccess when token (with writeAccess) is valid and minutes are found", async () => {
@@ -53,6 +55,8 @@ describe("minutesApi", () => {
       expect(response.status).toBe(200);
       expect(response.body.data).toEqual(expect.objectContaining(dummyMinutes));
       expect(response.body.writeAccess).toBe(true);
+      expect(response.body.readToken).toBeDefined();
+      expect(response.body.writeToken).toBeDefined();
     });
 
     it("should respond with 404 and error message when id doesn't exist in the database", async () => {

--- a/server/src/tests/api.test.js
+++ b/server/src/tests/api.test.js
@@ -4,7 +4,10 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 import app from "../app.js";
 import dummyMinutes from "../../data/dummyMinutes.json";
 import Minutes from "../entities/minutes.js";
-import { createJwt } from "../controllers/minutesController.helpers.js";
+import {
+  createJwt,
+  parseJwt,
+} from "../controllers/minutesController.helpers.js";
 
 describe("minutesApi", () => {
   const baseUrl = "/api/minutes";
@@ -37,7 +40,7 @@ describe("minutesApi", () => {
   const getTokenWithWriteAccess = (id) => createJwt(id, true);
 
   describe("get", () => {
-    it("should responds with 200, minutes and writeAccess when token (without writeAccess) is valid and minutes are found", async () => {
+    it("should responds with 200, minutes, writeAccess and readToken when token (without writeAccess) is valid and minutes are found", async () => {
       const token = getTokenWithoutWriteAccess(minutesInDb.id);
       const response = await api.get(`${baseUrl}/${token}`);
 
@@ -48,7 +51,17 @@ describe("minutesApi", () => {
       expect(response.body.writeToken).not.toBeDefined();
     });
 
-    it("should responds with 200, minutes and writeAccess when token (with writeAccess) is valid and minutes are found", async () => {
+    it("should give valid readToken that includes the correct minutes id and denied writeAccess when fetched with readToken", async () => {
+      const token = getTokenWithoutWriteAccess(minutesInDb.id);
+      const response = await api.get(`${baseUrl}/${token}`);
+
+      const parsedReadToken = await parseJwt(response.body.readToken);
+
+      expect(parsedReadToken.id).toBe(minutesInDb.id);
+      expect(parsedReadToken.writeAccess).toBe(false);
+    });
+
+    it("should responds with 200, minutes, writeAccess, readToken and writeToken when token (with writeAccess) is valid and minutes are found", async () => {
       const token = getTokenWithWriteAccess(minutesInDb.id);
       const response = await api.get(`${baseUrl}/${token}`);
 
@@ -57,6 +70,20 @@ describe("minutesApi", () => {
       expect(response.body.writeAccess).toBe(true);
       expect(response.body.readToken).toBeDefined();
       expect(response.body.writeToken).toBeDefined();
+    });
+
+    it("should give valid readToken and writeToken that include the correct minutes id and proper writeAccess when fetched with writeToken", async () => {
+      const token = getTokenWithWriteAccess(minutesInDb.id);
+      const response = await api.get(`${baseUrl}/${token}`);
+
+      const parsedReadToken = await parseJwt(response.body.readToken);
+      const parsedWriteToken = await parseJwt(response.body.writeToken);
+
+      expect(parsedReadToken.id).toBe(minutesInDb.id);
+      expect(parsedReadToken.writeAccess).toBe(false);
+
+      expect(parsedWriteToken.id).toBe(minutesInDb.id);
+      expect(parsedWriteToken.writeAccess).toBe(true);
     });
 
     it("should respond with 404 and error message when id doesn't exist in the database", async () => {


### PR DESCRIPTION
- Added tokens to GET response so share feature is available even when the minutes have not just been created
- When fetched with readToken, writeToken is not returned
- Changed GET response validator in frontend
- Created new tests for these changes

Closes #142 