### PR TITLE
add fonts to mui theme

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lilita+One&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&family=Tilt+Neon&display=swap" rel="stylesheet">
     <title>TableBook</title>
   </head>
   <body style="margin: 0">

--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lilita+One&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&family=Tilt+Neon&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lilita+One&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <title>TableBook</title>
   </head>
   <body style="margin: 0">

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -32,10 +32,9 @@ const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: {
-      header: ["Lilitia One", "sans-serif"].join(","),
-      editor: ["Roboto", "sans-serif"].join(","),
-      general: ["Tilt Neon", "sans-serif"].join(","),
+    fontFamily: ["Roboto", "sans-serif"].join(","), // default font
+    h3: {
+      fontFamily: ["Lilita One", "sans-serif"].join(","), // font family for h3/header
     },
   },
 });

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -31,6 +31,13 @@ const theme = createTheme({
       contrastText: "#ffffff",
     },
   },
+  typography: {
+    fontFamily: {
+      header: ["Lilitia One", "sans-serif"].join(","),
+      editor: ["Roboto", "sans-serif"].join(","),
+      general: ["Tilt Neon", "sans-serif"].join(","),
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
- Added fonts to the theme
- Ended up using two fonts instead of three (yksinkertainen on kaunista)
- Default font applies automatically everywhere but title
- Fonts can be played around and changed afterwards!
- "sans-serif" is system default font, is used when the primary font fails to load

closes #52  