### PR TITLE
185 allow many signatures

### DIFF
--- a/client/src/components/Editor/Editor.jsx
+++ b/client/src/components/Editor/Editor.jsx
@@ -35,13 +35,6 @@ function Editor() {
       flexDirection: "row",
       minHeight: 100,
     },
-
-    bottomContentContainer: {
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "end",
-      width: 1000,
-    },
   };
 
   return (
@@ -70,9 +63,7 @@ function Editor() {
             <SideContainer>
               <SignatureButtons signatureIndex={index} />
             </SideContainer>
-            <Box sx={styles.bottomContentContainer}>
-              <Signature signatureIndex={index} />
-            </Box>
+            <Signature signatureIndex={index} />
           </Box>
         ))}
       </Box>

--- a/client/src/components/Editor/Editor.jsx
+++ b/client/src/components/Editor/Editor.jsx
@@ -7,6 +7,7 @@ import SegmentButtons from "./SegmentButtons";
 import Segment from "./Segment";
 import Signature from "./Signature";
 import MinutesContext from "../../contexts/MinutesContext";
+import SignatureButtons from "./SignatureButtons";
 
 function Editor() {
   const [minutesState] = useContext(MinutesContext);
@@ -65,7 +66,9 @@ function Editor() {
         {minutesState.minutes.signatures.map((signature, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <Box sx={styles.bottomContainer} key={index}>
-            <SideContainer />
+            <SideContainer>
+              <SignatureButtons signatureIndex={index} />
+            </SideContainer>
             <Box sx={styles.bottomContentContainer}>
               <Signature signatureIndex={index} />
             </Box>

--- a/client/src/components/Editor/Editor.jsx
+++ b/client/src/components/Editor/Editor.jsx
@@ -62,12 +62,15 @@ function Editor() {
           </SegmentContainer>
         ))}
 
-        <Box sx={styles.bottomContainer}>
-          <SideContainer />
-          <Box sx={styles.bottomContentContainer}>
-            <Signature />
+        {minutesState.minutes.signatures.map((signature, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Box sx={styles.bottomContainer} key={index}>
+            <SideContainer />
+            <Box sx={styles.bottomContentContainer}>
+              <Signature signatureIndex={index} />
+            </Box>
           </Box>
-        </Box>
+        ))}
       </Box>
     </Box>
   );

--- a/client/src/components/Editor/Editor.jsx
+++ b/client/src/components/Editor/Editor.jsx
@@ -33,6 +33,7 @@ function Editor() {
       display: "flex",
       flexGrow: 1,
       flexDirection: "row",
+      minHeight: 100,
     },
 
     bottomContentContainer: {

--- a/client/src/components/Editor/Editor.test.jsx
+++ b/client/src/components/Editor/Editor.test.jsx
@@ -1,26 +1,36 @@
 import React from "react";
-import { expect, test, describe, beforeEach } from "vitest";
+import { expect, test, describe, beforeEach, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { I18nextProvider } from "react-i18next";
 import Editor from "./Editor";
 import i18n from "../../i18n/config";
 import MinutesContext from "../../contexts/MinutesContext";
+import EditorContext from "../../contexts/EditorContext";
 import theme from "../../theme";
-import { mockMinutesContextState } from "../../util/test.helpers";
+import {
+  mockMinutesContextState,
+  mockEditorContextState,
+} from "../../util/test.helpers";
 
 describe("Editor", () => {
   const renderWith = (mockMinutesState) => {
     render(
       <MinutesContext.Provider value={[mockMinutesState, {}]}>
-        <ThemeProvider theme={theme}>
-          <I18nextProvider i18n={i18n}>
-            <Editor />
-          </I18nextProvider>
-        </ThemeProvider>
+        <EditorContext.Provider value={[mockEditorContextState]}>
+          <ThemeProvider theme={theme}>
+            <I18nextProvider i18n={i18n}>
+              <Editor />
+            </I18nextProvider>
+          </ThemeProvider>
+        </EditorContext.Provider>
       </MinutesContext.Provider>,
     );
   };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
   describe("with writeAccess", () => {
     beforeEach(() => {
@@ -45,9 +55,20 @@ describe("Editor", () => {
       );
     });
 
-    test("renders signature component", () => {
-      const signatureComponent = screen.getByTestId("signature-component");
-      expect(signatureComponent).toBeDefined();
+    test("renders the right amount of signature components", () => {
+      const signatureComponents = screen.getAllByTestId("signature-component");
+      expect(signatureComponents.length).toBe(
+        mockMinutesContextState.minutes.signatures.length,
+      );
+    });
+
+    test("renders the right amount of signatureButton components", () => {
+      const signatureButtonComponents =
+        screen.getAllByTestId("signature-buttons");
+
+      expect(signatureButtonComponents.length).toBe(
+        mockMinutesContextState.minutes.signatures.length,
+      );
     });
   });
 
@@ -56,6 +77,12 @@ describe("Editor", () => {
       const segmentButtonComponents =
         screen.queryAllByTestId("segment-buttons");
       expect(segmentButtonComponents.length).toBe(0);
+    });
+
+    test("doesn't render any signatureButton components", () => {
+      const signatureButtonComponents =
+        screen.queryAllByTestId("signature-buttons");
+      expect(signatureButtonComponents.length).toBe(0);
     });
   });
 });

--- a/client/src/components/Editor/Segment.test.jsx
+++ b/client/src/components/Editor/Segment.test.jsx
@@ -168,14 +168,20 @@ describe("Segment", () => {
       });
     });
 
-    describe("without signatures", () => {
+    describe("with empty signatures", () => {
       beforeEach(() => {
         vi.stubGlobal("confirm", vi.fn());
         renderWith({
           ...mockMinutesContextState,
           minutes: {
             ...mockMinutesContextState.minutes,
-            signatures: [],
+            signatures: [
+              {
+                signer: "",
+                timestamp: null,
+                image: null,
+              },
+            ],
           },
         });
       });

--- a/client/src/components/Editor/SegmentButtons.test.jsx
+++ b/client/src/components/Editor/SegmentButtons.test.jsx
@@ -379,7 +379,7 @@ describe("SegmentButtons", () => {
     });
   });
 
-  describe("Without signatures", () => {
+  describe("With empty signatures", () => {
     describe("Delete button", () => {
       beforeEach(() => {
         vi.stubGlobal("confirm", vi.fn());
@@ -397,7 +397,13 @@ describe("SegmentButtons", () => {
             minutes: {
               ...mockMinutesContextState.minutes,
               segments: customSegments,
-              signatures: [],
+              signatures: [
+                {
+                  signer: "",
+                  timestamp: null,
+                  image: null,
+                },
+              ],
             },
           });
         });

--- a/client/src/components/Editor/Signature.jsx
+++ b/client/src/components/Editor/Signature.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import MinutesContext from "../../contexts/MinutesContext";
 import ImageElement from "../Shared/Image";
 
-function Signature() {
+function Signature({ signatureIndex }) {
   const { t } = useTranslation();
   const [state] = useContext(MinutesContext);
 
@@ -63,23 +63,21 @@ function Signature() {
       data-testid="signature-component"
     >
       <Box sx={styles.signatureContainer}>
-        {state.minutes.signatures.length > 0 &&
-          state.minutes.signatures[0].image && (
-            <ImageElement
-              src={state.minutes.signatures[0].image}
-              sx={styles.signatureImage}
-              alt="Signature"
-            />
-          )}
+        {state.minutes.signatures[signatureIndex].image && (
+          <ImageElement
+            src={state.minutes.signatures[signatureIndex].image}
+            sx={styles.signatureImage}
+            alt="Signature"
+          />
+        )}
 
         <Box sx={styles.signatureAndDateLine} />
 
-        {state.minutes.signatures.length > 0 &&
-          state.minutes.signatures[0].signer && (
-            <Typography variant="h5" sx={styles.signatureAndDateText}>
-              {state.minutes.signatures[0].signer}
-            </Typography>
-          )}
+        {state.minutes.signatures[signatureIndex].signer && (
+          <Typography variant="h5" sx={styles.signatureAndDateText}>
+            {state.minutes.signatures[signatureIndex].signer}
+          </Typography>
+        )}
 
         <Typography variant="h5" sx={styles.signatureAndDateText}>
           {t("signature")}
@@ -87,21 +85,20 @@ function Signature() {
       </Box>
 
       <Box sx={styles.dateContainer}>
-        {state.minutes.signatures.length > 0 &&
-          state.minutes.signatures[0].timestamp && (
-            <Box sx={styles.timestampContainer}>
-              <Typography variant="h5" sx={styles.signatureAndDateText}>
-                {moment
-                  .utc(state.minutes.signatures[0].timestamp)
-                  .format("YYYY-MM-DD")}
-              </Typography>
-              <Typography variant="h5" sx={styles.signatureAndDateText}>
-                {moment
-                  .utc(state.minutes.signatures[0].timestamp)
-                  .format("HH:mm z")}
-              </Typography>
-            </Box>
-          )}
+        {state.minutes.signatures[signatureIndex].timestamp && (
+          <Box sx={styles.timestampContainer}>
+            <Typography variant="h5" sx={styles.signatureAndDateText}>
+              {moment
+                .utc(state.minutes.signatures[signatureIndex].timestamp)
+                .format("YYYY-MM-DD")}
+            </Typography>
+            <Typography variant="h5" sx={styles.signatureAndDateText}>
+              {moment
+                .utc(state.minutes.signatures[signatureIndex].timestamp)
+                .format("HH:mm z")}
+            </Typography>
+          </Box>
+        )}
 
         <Box sx={styles.signatureAndDateLine} />
 

--- a/client/src/components/Editor/Signature.jsx
+++ b/client/src/components/Editor/Signature.jsx
@@ -10,6 +10,13 @@ function Signature({ signatureIndex }) {
   const [state] = useContext(MinutesContext);
 
   const styles = {
+    mainContainer: {
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "end",
+      width: 1000,
+    },
+
     dateAndSignatureContainer: {
       display: "flex",
       flexDirection: "row",
@@ -58,53 +65,52 @@ function Signature({ signatureIndex }) {
   };
 
   return (
-    <Box
-      sx={styles.dateAndSignatureContainer}
-      data-testid="signature-component"
-    >
-      <Box sx={styles.signatureContainer}>
-        {state.minutes.signatures[signatureIndex].image && (
-          <ImageElement
-            src={state.minutes.signatures[signatureIndex].image}
-            sx={styles.signatureImage}
-            alt="Signature"
-          />
-        )}
+    <Box sx={styles.mainContainer} data-testid="signature-component">
+      <Box sx={styles.dateAndSignatureContainer}>
+        <Box sx={styles.signatureContainer}>
+          {state.minutes.signatures[signatureIndex].image && (
+            <ImageElement
+              src={state.minutes.signatures[signatureIndex].image}
+              sx={styles.signatureImage}
+              alt="Signature"
+            />
+          )}
 
-        <Box sx={styles.signatureAndDateLine} />
+          <Box sx={styles.signatureAndDateLine} />
 
-        {state.minutes.signatures[signatureIndex].signer && (
+          {state.minutes.signatures[signatureIndex].signer && (
+            <Typography variant="h5" sx={styles.signatureAndDateText}>
+              {state.minutes.signatures[signatureIndex].signer}
+            </Typography>
+          )}
+
           <Typography variant="h5" sx={styles.signatureAndDateText}>
-            {state.minutes.signatures[signatureIndex].signer}
+            {t("signature")}
           </Typography>
-        )}
+        </Box>
 
-        <Typography variant="h5" sx={styles.signatureAndDateText}>
-          {t("signature")}
-        </Typography>
-      </Box>
+        <Box sx={styles.dateContainer}>
+          {state.minutes.signatures[signatureIndex].timestamp && (
+            <Box sx={styles.timestampContainer}>
+              <Typography variant="h5" sx={styles.signatureAndDateText}>
+                {moment
+                  .utc(state.minutes.signatures[signatureIndex].timestamp)
+                  .format("YYYY-MM-DD")}
+              </Typography>
+              <Typography variant="h5" sx={styles.signatureAndDateText}>
+                {moment
+                  .utc(state.minutes.signatures[signatureIndex].timestamp)
+                  .format("HH:mm z")}
+              </Typography>
+            </Box>
+          )}
 
-      <Box sx={styles.dateContainer}>
-        {state.minutes.signatures[signatureIndex].timestamp && (
-          <Box sx={styles.timestampContainer}>
-            <Typography variant="h5" sx={styles.signatureAndDateText}>
-              {moment
-                .utc(state.minutes.signatures[signatureIndex].timestamp)
-                .format("YYYY-MM-DD")}
-            </Typography>
-            <Typography variant="h5" sx={styles.signatureAndDateText}>
-              {moment
-                .utc(state.minutes.signatures[signatureIndex].timestamp)
-                .format("HH:mm z")}
-            </Typography>
-          </Box>
-        )}
+          <Box sx={styles.signatureAndDateLine} />
 
-        <Box sx={styles.signatureAndDateLine} />
-
-        <Typography variant="h5" sx={styles.signatureAndDateText}>
-          {t("date")}
-        </Typography>
+          <Typography variant="h5" sx={styles.signatureAndDateText}>
+            {t("date")}
+          </Typography>
+        </Box>
       </Box>
     </Box>
   );

--- a/client/src/components/Editor/Signature.test.jsx
+++ b/client/src/components/Editor/Signature.test.jsx
@@ -8,37 +8,59 @@ import MinutesContext from "../../contexts/MinutesContext";
 import { mockMinutesContextState } from "../../util/test.helpers";
 
 describe("Signature", () => {
-  beforeEach(() => {
+  const renderWith = (signatureIndex) => {
     render(
       <MinutesContext.Provider value={[mockMinutesContextState, {}]}>
         <I18nextProvider i18n={i18n}>
-          <Signature />
+          <Signature signatureIndex={signatureIndex} />
         </I18nextProvider>
       </MinutesContext.Provider>,
     );
+  };
+
+  describe("with signature that has content", () => {
+    beforeEach(() => {
+      renderWith(0);
+    });
+
+    test("renders signature and date sections", () => {
+      const signatureSection = screen.getByText("Signature");
+      const dateSection = screen.getByText("Date");
+      expect(signatureSection).toBeInTheDocument();
+      expect(dateSection).toBeInTheDocument();
+    });
+
+    test("renders signature image with correct source", () => {
+      const signatureImage = screen.getByAltText("Signature");
+      expect(signatureImage).toBeInTheDocument();
+      expect(signatureImage.src).toEqual(
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAB7CAYAAACb4F7QAAAAAXNSR0I",
+      );
+    });
+
+    test("renders signer name clarification", () => {
+      const nameClarification = screen.getByText("Test User");
+      expect(nameClarification).toBeInTheDocument();
+    });
+
+    test("renders date timestamp", () => {
+      const dateString = screen.getByText("2024-03-30");
+      const timeString = screen.getByText("00:00 UTC");
+      expect(dateString).toBeInTheDocument();
+      expect(timeString).toBeInTheDocument();
+    });
   });
 
-  test("renders signature and date sections", () => {
-    const signatureSection = screen.getByText("Signature");
-    const dateSection = screen.getByText("Date");
-    expect(signatureSection).toBeInTheDocument();
-    expect(dateSection).toBeInTheDocument();
-  });
+  describe("with empty signature", () => {
+    beforeEach(() => {
+      renderWith(1);
+    });
 
-  test("renders signature image with correct source", () => {
-    const signatureImage = screen.getByAltText("Signature");
-    expect(signatureImage).toBeInTheDocument();
-  });
-
-  test("renders signer name clarification", () => {
-    const nameClarification = screen.getByText("Test User");
-    expect(nameClarification).toBeInTheDocument();
-  });
-
-  test("renders date timestamp", () => {
-    const dateString = screen.getByText("2024-03-30");
-    const timeString = screen.getByText("00:00 UTC");
-    expect(dateString).toBeInTheDocument();
-    expect(timeString).toBeInTheDocument();
+    test("renders signature and date sections", () => {
+      const signatureSection = screen.getByText("Signature");
+      const dateSection = screen.getByText("Date");
+      expect(signatureSection).toBeInTheDocument();
+      expect(dateSection).toBeInTheDocument();
+    });
   });
 });

--- a/client/src/components/Editor/SignatureButtons.jsx
+++ b/client/src/components/Editor/SignatureButtons.jsx
@@ -50,7 +50,7 @@ function SignatureButtons({ signatureIndex }) {
   };
 
   return (
-    <Box sx={styles.buttonsContainer} data-testid="segment-buttons">
+    <Box sx={styles.buttonsContainer} data-testid="signature-buttons">
       <IconButton
         size="small"
         onClick={handleDelete}

--- a/client/src/components/Editor/SignatureButtons.jsx
+++ b/client/src/components/Editor/SignatureButtons.jsx
@@ -1,0 +1,76 @@
+import React, { useContext } from "react";
+import { Box, IconButton, useTheme } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import DrawIcon from "@mui/icons-material/Draw";
+import { useTranslation } from "react-i18next";
+import EditorContext from "../../contexts/EditorContext";
+import MinutesContext from "../../contexts/MinutesContext";
+
+function SignatureButtons({ signatureIndex }) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  const [minutesState, { updateMinutes }] = useContext(MinutesContext);
+  const [, updateEditor] = useContext(EditorContext);
+
+  const styles = {
+    buttonsContainer: {
+      display: "flex",
+      flexDirection: "column",
+    },
+
+    iconButton: {
+      padding: 0,
+    },
+
+    iconSize: {
+      fontSize: theme.fontSizes.l,
+    },
+  };
+
+  const handleDelete = () => {
+    const signature = minutesState.minutes.signatures[signatureIndex];
+    const isSignatureEmpty =
+      !signature.image && !signature.signer && !signature.timestamp;
+
+    if (!isSignatureEmpty && !window.confirm(t("deleteSignature"))) {
+      return;
+    }
+
+    const newSignatures = structuredClone(minutesState.minutes.signatures);
+    newSignatures.splice(signatureIndex, 1);
+    updateMinutes({ signatures: newSignatures });
+  };
+
+  const handleSignButtonClick = () => {
+    updateEditor({
+      isSignatureModalOpen: true,
+      signatureIndex,
+    });
+  };
+
+  return (
+    <Box sx={styles.buttonsContainer} data-testid="segment-buttons">
+      <IconButton
+        size="small"
+        onClick={handleDelete}
+        sx={styles.iconButton}
+        data-testid="deleteButton"
+      >
+        <DeleteIcon sx={styles.iconSize} />
+      </IconButton>
+
+      <IconButton
+        size="small"
+        title={t("sign")}
+        onClick={handleSignButtonClick}
+        sx={{ ...styles.iconButton, mb: 2 }}
+        data-testid="signButton"
+      >
+        <DrawIcon sx={styles.iconSize} />
+      </IconButton>
+    </Box>
+  );
+}
+
+export default SignatureButtons;

--- a/client/src/components/Editor/SignatureButtons.test.jsx
+++ b/client/src/components/Editor/SignatureButtons.test.jsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { I18nextProvider } from "react-i18next";
+import theme from "../../theme";
+import i18n from "../../i18n/config";
+import MinutesContext from "../../contexts/MinutesContext";
+import EditorContext from "../../contexts/EditorContext";
+import {
+  mockMinutesContextState,
+  mockEditorContextState,
+} from "../../util/test.helpers";
+import SignatureButtons from "./SignatureButtons";
+
+describe("SignatureButtons", () => {
+  const updateMinutesMock = vi.fn();
+  const updateEditorMock = vi.fn();
+
+  const renderWith = (signatureIndex) => {
+    render(
+      <MinutesContext.Provider
+        value={[
+          mockMinutesContextState,
+          {
+            updateMinutes: updateMinutesMock,
+          },
+        ]}
+      >
+        <EditorContext.Provider
+          value={[mockEditorContextState, updateEditorMock]}
+        >
+          <ThemeProvider theme={theme}>
+            <I18nextProvider i18n={i18n}>
+              <SignatureButtons signatureIndex={signatureIndex} />
+            </I18nextProvider>
+          </ThemeProvider>
+        </EditorContext.Provider>
+      </MinutesContext.Provider>,
+    );
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("delete button", () => {
+    describe("with signature that has content", () => {
+      beforeEach(() => {
+        vi.stubGlobal("confirm", vi.fn());
+        renderWith(0);
+      });
+
+      test("renders", () => {
+        const deleteButton = screen.getByTestId("deleteButton");
+        expect(deleteButton).toBeInTheDocument();
+      });
+
+      test("on delete confirmation confirm, deletes the signature field", async () => {
+        window.confirm.mockReturnValue(true);
+
+        const deleteButton = screen.getByTestId("deleteButton");
+
+        deleteButton.click();
+
+        await waitFor(() => {
+          expect(window.confirm).toHaveBeenCalledOnce();
+          expect(updateMinutesMock).toHaveBeenCalledOnce();
+          expect(updateMinutesMock).toHaveBeenCalledWith({
+            signatures: [
+              {
+                signer: "",
+                timestamp: null,
+                image: null,
+              },
+            ],
+          });
+        });
+      });
+
+      test("on delete confirmation cancel, doesnt call updateMinutes", async () => {
+        window.confirm.mockReturnValue(false);
+
+        const deleteButton = screen.getByTestId("deleteButton");
+
+        deleteButton.click();
+
+        await waitFor(() => {
+          expect(window.confirm).toHaveBeenCalledOnce();
+          expect(updateMinutesMock).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("with an empty signature", () => {
+      beforeEach(() => {
+        vi.stubGlobal("confirm", vi.fn());
+        renderWith(1);
+      });
+
+      test("deletes the signature field and doesnt ask confirmation", () => {
+        const deleteButton = screen.getByTestId("deleteButton");
+
+        deleteButton.click();
+
+        expect(window.confirm).not.toHaveBeenCalled();
+        expect(updateMinutesMock).toHaveBeenCalledOnce();
+        expect(updateMinutesMock).toHaveBeenCalledWith({
+          signatures: [
+            {
+              signer: "Test User",
+              timestamp: "2024-03-30T00:00:00.000Z",
+              image:
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAB7CAYAAACb4F7QAAAAAXNSR0I",
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  describe("sign button", () => {
+    beforeEach(() => {
+      renderWith(0);
+    });
+
+    test("renders", () => {
+      const signButton = screen.getByTestId("signButton");
+      expect(signButton).toBeInTheDocument();
+    });
+
+    test("opens signatureModal with right index", () => {
+      const signButton = screen.getByTestId("signButton");
+
+      signButton.click();
+
+      expect(updateEditorMock).toHaveBeenCalledOnce();
+      expect(updateEditorMock).toHaveBeenCalledWith({
+        isSignatureModalOpen: true,
+        signatureIndex: 0,
+      });
+    });
+  });
+});

--- a/client/src/components/Editor/Title.test.jsx
+++ b/client/src/components/Editor/Title.test.jsx
@@ -95,14 +95,20 @@ describe("Title", () => {
       });
     });
 
-    describe("without signatures", () => {
+    describe("with empty signatures", () => {
       beforeEach(() => {
         vi.stubGlobal("confirm", vi.fn());
         renderWith({
           ...mockMinutesContextState,
           minutes: {
             ...mockMinutesContextState.minutes,
-            signatures: [],
+            signatures: [
+              {
+                signer: "",
+                timestamp: null,
+                image: null,
+              },
+            ],
           },
         });
       });

--- a/client/src/components/PDFDocument.jsx
+++ b/client/src/components/PDFDocument.jsx
@@ -153,6 +153,7 @@ function PDFDocument({ pdfReadyMinutes }) {
       flexDirection: "row",
       marginTop: 20,
       justifyContent: "space-between",
+      minHeight: 75,
     },
 
     signatureContainer: {

--- a/client/src/components/PDFDocument.jsx
+++ b/client/src/components/PDFDocument.jsx
@@ -211,44 +211,38 @@ function PDFDocument({ pdfReadyMinutes }) {
             </View>
           ))}
         </View>
-        <View style={styles.signatureAndDateContainer}>
-          <View style={styles.signatureContainer}>
-            {pdfReadyMinutes.signatures.length > 0 &&
-              pdfReadyMinutes.signatures[0].image && (
-                <Image
-                  src={pdfReadyMinutes.signatures[0].image}
-                  style={styles.signatureImage}
-                />
+        {pdfReadyMinutes.signatures.map((signature, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <View key={index} style={styles.signatureAndDateContainer}>
+            <View style={styles.signatureContainer}>
+              {Boolean(signature.image) && (
+                <Image src={signature.image} style={styles.signatureImage} />
               )}
-            <View style={styles.signatureAndDateLine} />
-            {pdfReadyMinutes.signatures.length > 0 &&
-              pdfReadyMinutes.signatures[0].signer.length > 0 && (
+
+              <View style={styles.signatureAndDateLine} />
+              {Boolean(signature.signer) && (
                 <Text style={styles.signatureAndDateText}>
-                  {pdfReadyMinutes.signatures[0].signer}
+                  {signature.signer}
                 </Text>
               )}
-            <Text style={styles.signatureAndDateText}>{t("signature")}</Text>
-          </View>
-          <View style={styles.dateContainer}>
-            {pdfReadyMinutes.signatures.length > 0 &&
-              pdfReadyMinutes.signatures[0].timestamp && (
+              <Text style={styles.signatureAndDateText}>{t("signature")}</Text>
+            </View>
+            <View style={styles.dateContainer}>
+              {Boolean(signature.timestamp) && (
                 <View style={styles.timestampContainer}>
                   <Text style={styles.signatureAndDateText}>
-                    {moment
-                      .utc(pdfReadyMinutes.signatures[0].timestamp)
-                      .format("YYYY-MM-DD")}
+                    {moment.utc(signature.timestamp).format("YYYY-MM-DD")}
                   </Text>
                   <Text style={styles.signatureAndDateText}>
-                    {moment
-                      .utc(pdfReadyMinutes.signatures[0].timestamp)
-                      .format("HH:mm z")}
+                    {moment.utc(signature.timestamp).format("HH:mm z")}
                   </Text>
                 </View>
               )}
-            <View style={styles.signatureAndDateLine} />
-            <Text style={styles.signatureAndDateText}>{t("date")}</Text>
+              <View style={styles.signatureAndDateLine} />
+              <Text style={styles.signatureAndDateText}>{t("date")}</Text>
+            </View>
           </View>
-        </View>
+        ))}
       </Page>
     </Document>
   );

--- a/client/src/components/SideBar/SideBar.jsx
+++ b/client/src/components/SideBar/SideBar.jsx
@@ -3,14 +3,12 @@ import { Box, Button, useTheme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import ColorPickerContainer from "./ColorPickerContainer";
 import MinutesContext from "../../contexts/MinutesContext";
-import EditorContext from "../../contexts/EditorContext";
 import useHandleSignatureAffectingChange from "../../util/useHandleSignatureAffectingChange";
 
 function SideBar() {
   const theme = useTheme();
   const { t } = useTranslation();
   const [minutesState, { updateMinutes }] = useContext(MinutesContext);
-  const [, updateEditor] = useContext(EditorContext);
   const handleSignatureAffectingChange = useHandleSignatureAffectingChange();
 
   const styles = {
@@ -54,6 +52,19 @@ function SideBar() {
     updateMinutes({ segments: newSegments });
   };
 
+  const handleAddSignatureField = () => {
+    const newSignatures = [
+      ...minutesState.minutes.signatures,
+      {
+        image: null,
+        signer: "",
+        timestamp: null,
+      },
+    ];
+
+    updateMinutes({ signatures: newSignatures });
+  };
+
   return (
     <Box sx={styles.sideBarContainer}>
       {!(minutesState.metadata.writeAccess === false) && ( // If writeAccess is anything other than false
@@ -76,9 +87,9 @@ function SideBar() {
               variant="contained"
               color="secondary"
               sx={styles.sideBarButton}
-              onClick={() => updateEditor({ isSignatureModalOpen: true })}
+              onClick={handleAddSignatureField}
             >
-              {t("sign")}
+              {t("addSignatureField")}
             </Button>
           </>
         )}

--- a/client/src/components/SideBar/SideBar.test.jsx
+++ b/client/src/components/SideBar/SideBar.test.jsx
@@ -5,43 +5,32 @@ import { I18nextProvider } from "react-i18next";
 import { ThemeProvider } from "@mui/material/styles";
 import i18n from "../../i18n/config";
 import MinutesContext from "../../contexts/MinutesContext";
-import EditorContext from "../../contexts/EditorContext";
 import theme from "../../theme";
 import SideBar from "./SideBar";
 import useHandleSignatureAffectingChange from "../../util/useHandleSignatureAffectingChange";
 import { mockMinutesContextState } from "../../util/test.helpers";
 
 describe("SideBar", () => {
-  const updateEditorMock = vi.fn();
   const updateMinutesMock = vi.fn();
   const clearSignaturesMock = vi.fn();
 
   const renderWith = (minutesMockState) => {
     render(
-      <EditorContext.Provider
+      <MinutesContext.Provider
         value={[
+          minutesMockState,
           {
-            isSignatureModalOpen: false,
+            updateMinutes: updateMinutesMock,
+            clearSignatures: clearSignaturesMock,
           },
-          updateEditorMock,
         ]}
       >
-        <MinutesContext.Provider
-          value={[
-            minutesMockState,
-            {
-              updateMinutes: updateMinutesMock,
-              clearSignatures: clearSignaturesMock,
-            },
-          ]}
-        >
-          <ThemeProvider theme={theme}>
-            <I18nextProvider i18n={i18n}>
-              <SideBar />
-            </I18nextProvider>
-          </ThemeProvider>
-        </MinutesContext.Provider>
-      </EditorContext.Provider>,
+        <ThemeProvider theme={theme}>
+          <I18nextProvider i18n={i18n}>
+            <SideBar />
+          </I18nextProvider>
+        </ThemeProvider>
+      </MinutesContext.Provider>,
     );
   };
 
@@ -64,16 +53,39 @@ describe("SideBar", () => {
         expect(colorPickerContainer).toBeDefined();
       });
 
-      test("renders the sign button", () => {
-        const signButton = screen.getByText("Sign", { selector: "button" });
-        expect(signButton).toBeDefined();
+      test("renders the add signature field button", () => {
+        const addSignatureFieldButton = screen.getByText(
+          "Add Signature Field",
+          { selector: "button" },
+        );
+        expect(addSignatureFieldButton).toBeDefined();
       });
 
-      test("handles updateEditor when the sign button is pressed", () => {
-        const signButton = screen.getByText("Sign", { selector: "button" });
-        fireEvent.click(signButton);
-        expect(updateEditorMock).toHaveBeenCalledWith({
-          isSignatureModalOpen: true,
+      test("adds a new signature field on add signature field button click", () => {
+        const addSignatureFieldButton = screen.getByText(
+          "Add Signature Field",
+          { selector: "button" },
+        );
+        fireEvent.click(addSignatureFieldButton);
+        expect(updateMinutesMock).toHaveBeenCalledWith({
+          signatures: [
+            {
+              signer: "Test User",
+              timestamp: "2024-03-30T00:00:00.000Z",
+              image:
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAB7CAYAAACb4F7QAAAAAXNSR0I",
+            },
+            {
+              signer: "",
+              timestamp: null,
+              image: null,
+            },
+            {
+              signer: "",
+              timestamp: null,
+              image: null,
+            },
+          ],
         });
       });
     });
@@ -206,9 +218,14 @@ describe("SideBar", () => {
       expect(colorPickerContainer).not.toBeInTheDocument();
     });
 
-    test("doesn't render the sign button", () => {
-      const signButton = screen.queryByText("Sign", { selector: "button" });
-      expect(signButton).not.toBeInTheDocument();
+    test("doesn't render the add signature field button", () => {
+      const addSignatureFieldButton = screen.queryByText(
+        "Add Signature Field",
+        {
+          selector: "button",
+        },
+      );
+      expect(addSignatureFieldButton).not.toBeInTheDocument();
     });
 
     test("doesn't render add field button", () => {

--- a/client/src/components/SideBar/SideBar.test.jsx
+++ b/client/src/components/SideBar/SideBar.test.jsx
@@ -154,14 +154,20 @@ describe("SideBar", () => {
         });
       });
 
-      describe("without signatures", () => {
+      describe("with empty signatures", () => {
         beforeEach(() => {
           vi.stubGlobal("confirm", vi.fn());
           renderWith({
             ...mockMinutesContextState,
             minutes: {
               ...mockMinutesContextState.minutes,
-              signatures: [],
+              signatures: [
+                {
+                  signer: "",
+                  timestamp: null,
+                  image: null,
+                },
+              ],
             },
           });
         });

--- a/client/src/components/SignatureModal.jsx
+++ b/client/src/components/SignatureModal.jsx
@@ -103,15 +103,24 @@ function SignatureModal() {
     const image = !signaturePadRef.current.isEmpty()
       ? signaturePadRef.current.getTrimmedCanvas().toDataURL("image/png")
       : null;
-    updateMinutes({
-      signatures: [
-        {
-          signer,
-          timestamp,
-          image,
-        },
-      ],
-    });
+
+    const signature = state.minutes.signatures[editor.signatureIndex];
+    const isSignatureEmpty =
+      !signature.image && !signature.signer && !signature.timestamp;
+
+    if (!isSignatureEmpty) {
+      if (!window.confirm(t("overrideSignature"))) {
+        return;
+      }
+    }
+
+    const newSignatures = structuredClone(state.minutes.signatures);
+    newSignatures[editor.signatureIndex] = {
+      signer,
+      timestamp,
+      image,
+    };
+    updateMinutes({ signatures: newSignatures });
     handleModalClose();
   };
 

--- a/client/src/contexts/EditorContext.jsx
+++ b/client/src/contexts/EditorContext.jsx
@@ -5,6 +5,7 @@ const EditorContext = createContext();
 const initialState = {
   language: "en",
   isSignatureModalOpen: false,
+  signatureIndex: null,
   isPreviewPrintPDFModalOpen: false,
   sharePopupAnchorElement: null,
   reloadPopupAnchorElement: null,

--- a/client/src/contexts/MinutesContext.jsx
+++ b/client/src/contexts/MinutesContext.jsx
@@ -90,17 +90,17 @@ export function MinutesContextProvider({ children }) {
 
       clearSignatures: () => {
         setState((prevState) => {
+          const newSignatures = prevState.minutes.signatures.map(() => ({
+            image: null,
+            signer: "",
+            timestamp: null,
+          }));
+
           const newState = {
             ...prevState,
             minutes: {
               ...prevState.minutes,
-              signatures: [
-                {
-                  image: null,
-                  signer: "",
-                  timestamp: null,
-                },
-              ],
+              signatures: newSignatures,
             },
           };
           sessionStorage.setItem("MinutesContext", JSON.stringify(newState));

--- a/client/src/contexts/MinutesContext.jsx
+++ b/client/src/contexts/MinutesContext.jsx
@@ -24,7 +24,13 @@ const initialState = {
       },
     ],
     startTime: null,
-    signatures: [],
+    signatures: [
+      {
+        image: null,
+        signer: "",
+        timestamp: null,
+      },
+    ],
   },
 
   metadata: {
@@ -88,7 +94,13 @@ export function MinutesContextProvider({ children }) {
             ...prevState,
             minutes: {
               ...prevState.minutes,
-              signatures: [],
+              signatures: [
+                {
+                  image: null,
+                  signer: "",
+                  timestamp: null,
+                },
+              ],
             },
           };
           sessionStorage.setItem("MinutesContext", JSON.stringify(newState));

--- a/client/src/i18n/locales/en/translations.json
+++ b/client/src/i18n/locales/en/translations.json
@@ -5,11 +5,14 @@
   "restoreDefaults": "Restore Defaults",
   "addAField": "Add a field",
   "sign": "Sign",
+  "addSignatureField": "Add Signature Field",
 
   "enterTheMainTitle": "Enter the main title",
   "enterTheContent": "Enter the content",
   "enterTheTitle": "Enter the title",
   "deleteSegment": "This action will delete the segment and its content. Are you sure?",
+  "deleteSignature": "This action will delete the signature field. Are you sure?",
+  "overrideSignature": "This action will override the previous signature. Are you sure?",
   "signature": "Signature",
   "date": "Date",
 

--- a/client/src/i18n/locales/fi/translations.json
+++ b/client/src/i18n/locales/fi/translations.json
@@ -5,10 +5,13 @@
   "restoreDefaults": "Alkuperäisvärit",
   "addAField": "Lisää kenttä",
   "sign": "Allekirjoita",
+  "addSignatureField": "Lisää allekirjoituskenttä",
 
   "enterTheMainTitle": "Lisää otsikko",
   "enterTheContent": "Lisää sisältöä",
   "deleteSegment": "Osio poistuu sisältöineen. Vahvistetaanko?",
+  "deleteSignature": "Allekirjoitus poistuu. Vahvistetaanko?",
+  "overrideSignature": "Aikaisempi allekirjoitus ylikirjoitetaan. Vahvistetaanko?",
   "enterTheTitle": "Lisää alaotsikko",
   "signature": "Allekirjoitus",
   "date": "Päiväys",

--- a/client/src/util/test.helpers.js
+++ b/client/src/util/test.helpers.js
@@ -23,6 +23,11 @@ export const mockMinutesContextState = {
         image:
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAB7CAYAAACb4F7QAAAAAXNSR0I",
       },
+      {
+        signer: "",
+        timestamp: null,
+        image: null,
+      },
     ],
   },
 

--- a/client/src/util/useHandleSignatureAffectingChange.js
+++ b/client/src/util/useHandleSignatureAffectingChange.js
@@ -9,13 +9,16 @@ const useHandleSignatureAffectingChange = () => {
    * @returns Should signature affecting change go through?
    */
   const handleSignatureAffectingChange = () => {
-    const firstSignature = minutesState.minutes.signatures[0];
+    let isSignaturesEmpty = true;
 
-    const isSignaturesEmpty =
-      minutesState.minutes.signatures.length === 1 &&
-      !firstSignature.image &&
-      !firstSignature.signer &&
-      !firstSignature.timestamp;
+    Object.values(minutesState.minutes.signatures).forEach((signature) => {
+      const signatureHasValues =
+        signature.image || signature.signer || signature.timestamp;
+
+      if (signatureHasValues) {
+        isSignaturesEmpty = false;
+      }
+    });
 
     if (isSignaturesEmpty) {
       return true;

--- a/client/src/util/useHandleSignatureAffectingChange.js
+++ b/client/src/util/useHandleSignatureAffectingChange.js
@@ -9,7 +9,15 @@ const useHandleSignatureAffectingChange = () => {
    * @returns Should signature affecting change go through?
    */
   const handleSignatureAffectingChange = () => {
-    if (!minutesState.minutes.signatures.length) {
+    const firstSignature = minutesState.minutes.signatures[0];
+
+    const isSignaturesEmpty =
+      minutesState.minutes.signatures.length === 1 &&
+      !firstSignature.image &&
+      !firstSignature.signer &&
+      !firstSignature.timestamp;
+
+    if (isSignaturesEmpty) {
       return true;
     }
 

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -89,7 +89,7 @@ describe("Scenarios", () => {
     );
 
     // Sign
-    cy.contains("Sign").click();
+    cy.getByTestId("signButton").click();
     cy.get("canvas").should("exist");
     cy.getByPlaceHolder("Enter name clarification").type("Tester");
     cy.contains("Confirm").click();


### PR DESCRIPTION
- editor now maps the signatures array
- pdf now maps the signature array
- user can now add multiple signatures or choose to add none
- sign button was moved to beside every signature as a pencil icon and when it is clicked you can edit the signature
- every signature has a delete button that can be used to delete signatures
- sidebar now has add signature field button that adds an empty signature field to the signatures array
- added minHeight for the signature so there is enough space for a signature if user wants to sign it by hand after printing
- updated tests to match these changes