### PR TITLE
Footer buttons open on a new tab

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -35,6 +35,7 @@ function Footer() {
           to="https://github.com/tablebook/tablebook/issues/new"
           color="primary.contrastText"
           underline="hover"
+          target="_blank"
           data-testid="reportButton"
         >
           <ReportIcon />
@@ -48,6 +49,7 @@ function Footer() {
           to="https://github.com/tablebook/tablebook"
           color="primary.contrastText"
           underline="hover"
+          target="_blank"
           data-testid="gitHubButton"
         >
           <GitHubIcon />
@@ -61,6 +63,7 @@ function Footer() {
           to="https://github.com/tablebook/tablebook/blob/main/LICENSE"
           color="primary.contrastText"
           underline="hover"
+          target="_blank"
           data-testid="copyrightButton"
         >
           <CopyrightIcon sx={styles.iconSize} />

--- a/client/src/components/Footer.test.jsx
+++ b/client/src/components/Footer.test.jsx
@@ -28,12 +28,14 @@ describe("Footer", () => {
     expect(reportButton.href).toEqual(
       "https://github.com/tablebook/tablebook/issues/new",
     );
+    expect(reportButton).toHaveAttribute("target", "_blank");
   });
 
   test("renders github link", () => {
     const githubButton = screen.getByTestId("gitHubButton", { selector: "a" });
     expect(githubButton).toBeDefined();
     expect(githubButton.href).toEqual("https://github.com/tablebook/tablebook");
+    expect(githubButton).toHaveAttribute("target", "_blank");
   });
 
   test("renders copyright button", () => {
@@ -44,5 +46,6 @@ describe("Footer", () => {
     expect(copyrightButton.href).toEqual(
       "https://github.com/tablebook/tablebook/blob/main/LICENSE",
     );
+    expect(copyrightButton).toHaveAttribute("target", "_blank");
   });
 });


### PR DESCRIPTION
- Added attribute `target="_blank"` to open links on a new tab
- Updated tests to check that the links have this attribute on them