### PR TITLE
Updated downloaded PDF name

### DIFF
--- a/client/src/components/DownloadPDFButton.jsx
+++ b/client/src/components/DownloadPDFButton.jsx
@@ -42,7 +42,13 @@ function DownloadPDFButton({ variant, color, sx }) {
     ) {
       const link = document.createElement("a");
       link.href = PDFInstance.url;
-      link.download = `${minutesState.minutes.name.split(" ")[0]}_${moment().format("YYYY-MM-DD")}.pdf`;
+
+      // Create the filename for downloaded PDF based on the minutes title and current timestamp
+      const minutesTitle =
+        minutesState.minutes.name.trim().replace(/\s+/g, "_") || t("minutes");
+      const fileName = `${minutesTitle}_${moment().format("YYYY-MM-DD")}.pdf`;
+
+      link.download = fileName;
       document.body.appendChild(link);
       link.click();
       link.remove();
@@ -55,6 +61,7 @@ function DownloadPDFButton({ variant, color, sx }) {
     PDFInstance.error,
     triggerPDFDownload,
     minutesState.minutes.name,
+    t,
   ]);
 
   return (

--- a/client/src/components/PreviewPrintPDFModal.jsx
+++ b/client/src/components/PreviewPrintPDFModal.jsx
@@ -25,9 +25,10 @@ function PreviewPrintPDFModal() {
   const pdfDocumentHeight = "80dvh";
   const pdfDocumentWidth = `calc(${pdfDocumentHeight} * ${pdfDocumentRatio})`;
 
-  // Create the filename for downloaded PDF based on the minutes state and current timestamp
-  const titleFirstWord = minutesState.minutes.name.split(" ")[0];
-  const fileName = `${titleFirstWord}_${moment().format("YYYY-MM-DD")}.pdf`;
+  // Create the filename for downloaded PDF based on the minutes title and current timestamp
+  const minutesTitle =
+    minutesState.minutes.name.trim().replace(/\s+/g, "_") || t("minutes");
+  const fileName = `${minutesTitle}_${moment().format("YYYY-MM-DD")}.pdf`;
 
   const styles = {
     modalStyle: {

--- a/client/src/i18n/locales/en/translations.json
+++ b/client/src/i18n/locales/en/translations.json
@@ -48,6 +48,7 @@
   "loadedMinutesFail": "Reloading minutes failed",
   "sharingError": "Error while sharing minutes",
 
+  "minutes": "Minutes",
   "printPDF": "Print PDF",
   "downloadPDF": "Download PDF",
   "closeWindow": "Close window",

--- a/client/src/i18n/locales/fi/translations.json
+++ b/client/src/i18n/locales/fi/translations.json
@@ -48,6 +48,7 @@
   "loadedMinutesFail": "Pöytäkirjan päivittäminen epäonnistui",
   "sharingError": "Ongelma pöytäkirjan jakamisessa",
 
+  "minutes": "Pöytäkirja",
   "printPDF": "Tulosta PDF",
   "downloadPDF": "Lataa PDF",
   "closeWindow": "Sulje ikkuna",


### PR DESCRIPTION
- Now includes the whole title separated by underscores.
- If no title, will default to localized "Minutes"
- Updated on both PreviewPrintPDFModal for desktop and DownloadPDFButton on mobile
- Added localization for "Minutes"