### PR TITLE
Fixed PDFDocument signature rendering

### DIFF
--- a/client/src/components/PDFDocument.jsx
+++ b/client/src/components/PDFDocument.jsx
@@ -180,7 +180,8 @@ function PDFDocument({ pdfReadyMinutes }) {
     signatureImage: {
       width: 150,
       height: 60,
-      objectFit: "contain",
+      objectFit: "scale-down",
+      objectPosition: "0 100%",
     },
 
     signatureAndDateLine: {


### PR DESCRIPTION
- Does not stretch image if the signature is really small
- Starts the signature from the bottom left

fixes #234 